### PR TITLE
doc: make it explicit that stdin doesn't go through decoding and/or e…

### DIFF
--- a/doc/ezstream.1.in.in
+++ b/doc/ezstream.1.in.in
@@ -568,6 +568,11 @@ This element contains all decoder blocks as child elements.
 Its parent is the
 .Sy \&<ezstream\ /\&>
 element.
+.Pp
+.Em Note:
+Decoders are ignored for
+.Ar stdin
+intake.
 .El
 .Ss Decoder block
 .Bl -tag -width -Ds
@@ -620,6 +625,11 @@ This element contains all encoder blocks as child elements.
 Its parent is the
 .Sy \&<ezstream\ /\&>
 element.
+.Pp
+.Em Note:
+Encoders are ignored for
+.Ar stdin
+intake.
 .El
 .Ss Encoder block
 .Bl -tag -width -Ds

--- a/examples/ezstream-stdin.xml
+++ b/examples/ezstream-stdin.xml
@@ -19,6 +19,7 @@
     <stream>
       <mountpoint>/stream.ogg</mountpoint>
       <format>Ogg</format>
+      <!-- No encoder configured, not supported for stdin. -->
     </stream>
   </streams>
 


### PR DESCRIPTION
…ncoding

You can consider it as a bug report as I just wanted to capture sound with arecord and have ezstream encode it. Probably some suitable example for this usecase should be added to the documentation.

Another thing I'm missing is the ability to select between multiple defined streams via a command line argument, is this a desired feature or am I just misunderstanding something?